### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/1](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/1)

In general, the fix is to explicitly define the `permissions` for the `GITHUB_TOKEN` in the workflow, restricting them to the minimum required. Since this CI job only checks out repository contents and runs tests, it only needs read access to the repository contents, and no write permissions or additional scopes.

The single best fix without changing functionality is to add a `permissions:` block at the workflow root level, just under the `name: CI` (or just under `on:`), so it applies to all jobs. We set `contents: read`, which is sufficient for `actions/checkout@v4` and for running tests that only read the code. No other permissions (like `pull-requests`, `issues`, or `packages`) are clearly required from the shown snippet, so we omit them to keep least privilege. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

with correct indentation at the top level. No imports or additional methods are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
