### PR TITLE
Potential fix for code scanning alert no. 3: Deserialization of user-controlled data

### DIFF
--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1150,9 +1150,15 @@ class ModelCommands:
                     # Prefer safe, weights-only loading to avoid arbitrary code execution.
                     save_data = torch.load(path, map_location="cpu", weights_only=True)
                 except TypeError:
-                    # Older torch versions may not support weights_only; fall back to default,
-                    # which should still load state dict–style data for recent files.
-                    save_data = torch.load(path, map_location="cpu")
+                    # This PyTorch version does not support the weights_only argument.
+                    # To avoid unsafe deserialization with torch.load, refuse to load the file.
+                    return {
+                        "error": (
+                            "This environment uses an older PyTorch version that does not "
+                            "support safe weights-only loading. Please convert the model "
+                            "using a trusted offline tool with a newer PyTorch version and retry."
+                        )
+                    }
                 except Exception as e:
                     msg = str(e)
                     # Back-compat: previously this code attempted an unsafe fallback with

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1147,25 +1147,36 @@ class ModelCommands:
                 except Exception as e:
                     return {"error": f"Loading {ext} requires torch (import failed: {e})"}
                 try:
+                    # Prefer safe, weights-only loading to avoid arbitrary code execution.
+                    save_data = torch.load(path, map_location="cpu", weights_only=True)
+                except TypeError:
+                    # Older torch versions may not support weights_only; fall back to default,
+                    # which should still load state dict–style data for recent files.
                     save_data = torch.load(path, map_location="cpu")
                 except Exception as e:
                     msg = str(e)
-                    # Back-compat: handle older files that contained NumPy arrays.
+                    # Back-compat: previously this code attempted an unsafe fallback with
+                    # weights_only=False for legacy files. To avoid unsafe deserialization
+                    # from untrusted sources, we now refuse such files instead.
                     if "Weights only load failed" in msg or "weights_only" in msg:
-                        try:
-                            save_data = torch.load(path, map_location="cpu", weights_only=False)
-                            unsafe_load = True
-                        except TypeError:
-                            raise
-                    else:
-                        raise
+                        return {
+                            "error": (
+                                "This model file appears to use an unsupported legacy format "
+                                "that cannot be safely loaded. Please convert it using a "
+                                "trusted offline tool and retry."
+                            )
+                        }
+                    raise
                 fmt = "torch"
             else:
-                import pickle
-                with open(path, "rb") as f:
-                    save_data = pickle.load(f)
-                fmt = "pickle"
-            
+                # For security reasons, only PyTorch .pth/.pt files are supported by this loader.
+                return {
+                    "error": (
+                        f"Unsupported model file extension '{ext}'. "
+                        "Only .pth/.pt files are supported for loading."
+                    )
+                }
+
             model_type = save_data.get("model_type", "Unknown")
             config = save_data.get("config", {})
             state_dict = self._state_dict_to_numpy(save_data.get("state_dict", {}))
@@ -1177,7 +1188,7 @@ class ModelCommands:
                 "config": config,
                 "state_dict": state_dict,
             }
-            
+
             return {
                 "status": "success",
                 "model_id": model_id,


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/3](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/3)

In general, fixing unsafe deserialization means either (1) not deserializing untrusted data at all, or (2) constraining it to a safe format (e.g., JSON) or a safe loading mode that only loads plain data structures and tensors without executing arbitrary code. For PyTorch, that means using `weights_only=True` (or its equivalent) and only handling the tensor state dict, not arbitrary objects. For pickle, the best fix is to stop using it for untrusted data; if backward compatibility is needed for existing files, you can isolate it behind an explicit “unsafe” flag and/or restrict which files can be loaded.

For this codebase, the best targeted fix that preserves existing functionality is:

1. Restrict which files can be loaded via the REPL/UI: only allow `.pth` / `.pt` model files; disallow generic `.pkl`/other extensions from the web UI path, thereby removing untrusted `pickle.load` from user-controllable flows.
2. Make the torch deserialization safer:
   - Always first try `torch.load(path, map_location="cpu", weights_only=True)` (safe, tensors-only).
   - If that fails with the known “weights_only” errors, refuse to proceed from untrusted contexts instead of silently falling back to the unsafe legacy mode. Because we can’t see the rest of the code, the safest minimal change is to simply not call `torch.load(..., weights_only=False)` in response to untrusted input; instead, return an error explaining that legacy files aren’t supported in the UI.
3. Remove or gate the generic `pickle.load` path for user-controlled `path`. Since we’re asked not to assume anything beyond these snippets, the minimal safe change is to reject non‑`.pth`/`.pt` paths in `load_model` and return an error. This keeps the UI/REPL from ever triggering `pickle.load` on user-controlled data, while leaving room for trusted CLI code (not shown here) to have a different loader if needed.

Concretely in `rasptorch/CLI/_cli_commands.py`:

- Change the `if ext in {".pth", ".pt"}:` branch to:
  - Try safe `torch.load(..., weights_only=True)` in a `try` block.
  - If that fails due to legacy “weights_only” issues, return an error instead of falling back to unsafe deserialization.
- Replace the `else:` branch (which currently imports `pickle` and calls `pickle.load`) with a rejection of unsupported formats: return an error noting that only `.pth`/`.pt` files are supported for loading via this interface, instead of deserializing with pickle.

These changes are limited to the shown snippet, do not alter the external API shape (`load_model` still returns a dict), and remove all unsafe deserialization from user-controlled flows.
