### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/rasptorch/ui/app.py
+++ b/rasptorch/ui/app.py
@@ -2326,7 +2326,7 @@ def _render_save_page() -> None:
     if Path(save_name).suffix.lower() != str(save_type).lower():
         save_name = str(Path(save_name).with_suffix(str(save_type)))
 
-    dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
+    dl_ext = str(save_type).lower()
     with tempfile.NamedTemporaryFile(delete=False, suffix=dl_ext) as f:
         tmp_out = f.name
     res = cmds.save_model(selected, tmp_out)


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/11](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/11)

General approach: ensure that any string used as part of a filesystem path (even just a suffix) is either validated or derived from trusted/controlled data rather than directly from user input. In this case, we want the temporary file’s suffix (`dl_ext`) and the download filename to be based on the selected file type (`save_type`), which already comes from a fixed allow list, rather than from the user-typed `save_name`.

Concrete fix for this snippet:

- Keep allowing the user to type an arbitrary base filename, but always force its extension to be equal to the selected `save_type` (this is already done in lines 2325–2327).
- Change the computation of `dl_ext` so that it comes directly from `save_type`, not from `save_name`. This breaks the taint flow from `st.text_input` to `tempfile.NamedTemporaryFile`.
- Keep everything else unchanged to preserve functionality: `save_name` will still be used as the download filename, but the actual file created on disk will use a suffix derived from `save_type`, which is safe.

Specific change (in `rasptorch/ui/app.py` around lines 2325–2330):

- Replace `dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)` with `dl_ext = str(save_type).lower()`.

No new methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
