### PR TITLE
Potential fix for code scanning alert no. 20: Deserialization of user-controlled data

### DIFF
--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1169,14 +1169,23 @@ class ModelCommands:
         return candidate
 
     def _safe_torch_load(self, path: str) -> Dict[str, Any]:
-        """Safely load a torch checkpoint, preferring weights_only when available.
+        """Safely load a torch checkpoint, using weights_only=True to avoid
+        arbitrary object deserialization.
 
-        This helper only performs loads that do not require arbitrary object
-        deserialization. If safe loading is not supported by the installed
-        torch version or by the given file, it raises an exception instead of
-        falling back to an unsafe mode.
+        This helper is intentionally strict:
+        * It only allows loading standard PyTorch checkpoint files (.pt/.pth).
+        * It never falls back to an unsafe pickle-based load if weights_only is
+          not supported or fails for the given file.
         """
+        import os
         import torch  # type: ignore
+
+        # Defense in depth: ensure that only typical PyTorch checkpoint files are loaded.
+        ext = os.path.splitext(str(path))[1].lower()
+        if ext not in {".pt", ".pth"}:
+            raise RuntimeError(
+                f"Refusing to load non-torch checkpoint file with torch.load: {path}"
+            )
 
         try:
             # Prefer weights_only=True when supported by the installed torch version.
@@ -1185,7 +1194,8 @@ class ModelCommands:
             # Older torch without weights_only: refuse to perform an unsafe load.
             raise RuntimeError(
                 "Safe model loading is not supported by the installed torch version "
-                "(missing weights_only parameter). Refusing to load checkpoint."
+                "(missing weights_only parameter). Refusing to load checkpoint "
+                "to avoid unsafe deserialization."
             )
         except Exception as e:
             msg = str(e)
@@ -1195,6 +1205,7 @@ class ModelCommands:
                     "Checkpoint cannot be loaded safely with weights_only=True; "
                     "refusing to load due to potential unsafe deserialization."
                 ) from e
+            # Propagate other errors (I/O, corruption, etc.) as-is.
             raise
 
         if not isinstance(save_data, dict):


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/20](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/20)

General fix: ensure that no user-controlled data can cause unsafe deserialization. For PyTorch, that means never allowing a `torch.load` call that might fall back to full pickle-based deserialization, and constraining what files can be loaded and how. The current `_safe_torch_load` is already close: it uses `weights_only=True` and refuses to run when that’s unsupported or fails. We should reinforce this behavior and make it explicit that only `.pt`/`.pth` files loaded in this mode are allowed, and that any failure is surfaced as a safe error.

Best concrete fix here: keep the existing safe pattern but (a) ensure `_safe_torch_load` remains the only way we ever call `torch.load` for user-controlled paths, and (b) keep `load_model` strictly tied to `_safe_torch_load` for `.pt`/`.pth` files and JSON for others. The current snippet already does (a) and (b); the main risk is a future maintainer misunderstanding how strict `_safe_torch_load` is. To make the safety contract stronger without changing functionality, we can:

- Add a small guard in `_safe_torch_load` to explicitly reject non-`.pt`/`.pth` paths if it is ever called directly with some other extension.
- Slightly clarify error messages to emphasize that unsafe loading is intentionally refused.

These changes are limited to `rasptorch/CLI/_cli_commands.py` in the shown snippet and do not alter the outward behavior except for making some error messages clearer and slightly stricter if `_safe_torch_load` is misused elsewhere. The UI files (`rasptorch/ui/app.py` and `rasptorch/CLI/ui/app.py`) only read command text and pass strings through; they do not need changes for the deserialization issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
