### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1086,6 +1086,9 @@ class ModelCommands:
         if model_id not in self.models:
             return {"error": f"Model {model_id} not found"}
         try:
+            # Resolve and validate the target path to avoid writing outside the models directory.
+            safe_path = self._resolve_model_save_path(path)
+
             model_data = self.models[model_id]
             model = self._ensure_model(model_id)
             if model is None:
@@ -1133,25 +1136,54 @@ class ModelCommands:
                 "state_dict": state_dict,
             }
 
-            ext = os.path.splitext(str(path))[1].lower()
+            ext = os.path.splitext(str(safe_path))[1].lower()
             if ext in {".pth", ".pt"}:
-                save_checkpoint(path, save_data)
+                save_checkpoint(safe_path, save_data)
                 fmt = "rasptorch-npz"
             else:
                 import pickle
-                with open(path, "wb") as f:
+                with open(safe_path, "wb") as f:
                     pickle.dump(save_data, f)
                 fmt = "pickle"
             
             return {
                 "status": "success",
                 "model_id": model_id,
-                "path": path,
+                "path": safe_path,
                 "format": fmt,
                 "message": f"Model saved successfully",
             }
         except Exception as e:
             return {"error": str(e)}
+
+    def _resolve_model_save_path(self, path: str) -> str:
+        """
+        Resolve a user-supplied model save path to a safe absolute path within a
+        dedicated models directory.
+
+        This prevents saving models outside the intended directory via absolute
+        paths or '..' segments.
+        """
+        # Base directory for saved models – use a directory under the current
+        # working directory to avoid writing to arbitrary locations.
+        base_dir = os.path.abspath(os.path.join(os.getcwd(), "models"))
+        os.makedirs(base_dir, exist_ok=True)
+
+        # If the user gave an absolute path, interpret it relative to base_dir by
+        # stripping any leading path separator.
+        # This keeps behaviour similar (subdirectories still work) but confines
+        # writes to base_dir.
+        rel_path = str(path)
+        if os.path.isabs(rel_path):
+            rel_path = rel_path.lstrip(os.sep)
+
+        # Join and normalize, then ensure the result stays within base_dir.
+        joined = os.path.join(base_dir, rel_path)
+        safe_path = os.path.abspath(os.path.normpath(joined))
+        if not safe_path.startswith(base_dir + os.sep) and safe_path != base_dir:
+            raise ValueError("Invalid model save path")
+
+        return safe_path
 
     def _resolve_model_path(self, path: str) -> str:
         """Resolve a user-provided model path into a confined, normalized path.

--- a/rasptorch/checkpoint.py
+++ b/rasptorch/checkpoint.py
@@ -48,6 +48,10 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     back by `load_checkpoint` with `allow_pickle=False`.
     """
 
+    # Normalize the path to an absolute path. Callers are responsible for any
+    # additional validation or confinement to a safe directory.
+    safe_path = os.path.abspath(os.path.normpath(str(path)))
+
     state_dict = _state_dict_to_numpy(payload.get("state_dict", {}))
     payload_meta = {k: _json_safe(v) for k, v in dict(payload).items() if k != "state_dict"}
     state_keys = sorted(state_dict.keys())
@@ -62,7 +66,7 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     for i, key in enumerate(state_keys):
         archive_items[f"arr_{i}"] = state_dict[key]
 
-    with open(path, "wb") as f:
+    with open(safe_path, "wb") as f:
         np.savez_compressed(f, **archive_items)
     return "rasptorch-npz"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/25](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/25)

In general, to fix uncontrolled path usage you must constrain user-provided paths before using them in file operations. Typical strategies are: (1) force all file operations into a dedicated root directory and reject paths that escape it (using `os.path.normpath`/`realpath` and prefix checks), and (2) optionally restrict filenames (no path separators) if only simple names are needed.

Here, the best fix with minimal behavior change is to introduce a small path-sanitization helper in `rasptorch.checkpoint.save_checkpoint` and in `_cli_commands.SessionCommands.save_model` that normalizes the user-supplied `path`, anchors it in a safe base directory (for example a per-user or per-process model directory), and rejects attempts to escape that directory. Because we must not assume other project structure, we can use a simple base such as the current working directory or a subdirectory under it (e.g. `models`). We will:

1. In `rasptorch/CLI/_cli_commands.py`, add a helper method (or reuse `_resolve_model_path` if available in the unseen part) that:
   - Defines a base directory (e.g. a `.rasptorch_models` directory under the user’s home or current directory).
   - Normalizes and joins the user-specified `path` to that base.
   - Ensures the resulting absolute path starts with the base directory; if not, raises an error.
2. Call this resolver from `save_model` to produce a safe path before passing it to `save_checkpoint` or `open`.
3. In `rasptorch/checkpoint.save_checkpoint`, we will not re-interpret the path (it is already sanitized by the caller), but we can add a conservative normalization to avoid surprises (e.g. `os.path.abspath`), which does not weaken the previous safety check.

We only touch the shown code segments in `rasptorch/checkpoint.py` and `rasptorch/CLI/_cli_commands.py`. Necessary imports are already present (`os`, `tempfile`, etc.), so no new external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
