### PR TITLE
Fix code scanning alerts no. 25, 26, 27: Uncontrolled data used in path expression

### DIFF
--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1159,38 +1159,19 @@ class ModelCommands:
 
     def _resolve_model_save_path(self, path: str) -> str:
         """
-        Resolve a user-supplied model save path to a safe absolute path within a
-        dedicated models directory.
+        Resolve a user-supplied model save path using the same confinement logic
+        as `_resolve_model_path`.
 
-        This prevents saving models outside the intended directory via absolute
-        paths or '..' segments.
+        This ensures that both loading and saving models share a single, consistent
+        path-validation implementation.
         """
         raw = (path or "").strip()
         if not raw:
             raise ValueError("Model save path must not be empty")
-        if os.path.isabs(raw):
-            # Do not allow absolute paths; callers must use relative paths under the models directory.
-            raise ValueError("Absolute model save paths are not allowed")
 
-        # Base directory for saved models – use a directory under the current
-        # working directory to avoid writing to arbitrary locations.
-        base_dir = os.path.join(os.getcwd(), "models")
-        os.makedirs(base_dir, exist_ok=True)
-
-        # Join and normalize, then ensure the result stays within base_dir.
-        candidate = os.path.abspath(os.path.normpath(os.path.join(base_dir, raw)))
-        base_dir_abs = os.path.abspath(base_dir)
-
-        try:
-            common = os.path.commonpath([base_dir_abs, candidate])
-        except ValueError:
-            # Different drives on Windows, invalid paths, etc.
-            raise ValueError("Invalid model save path")
-        if common != base_dir_abs:
-            raise ValueError("Model save path escapes allowed directory")
-
-        return candidate
-
+        # Delegate to the shared model path resolver to avoid duplicated and
+        # potentially divergent validation logic.
+        return self._resolve_model_path(raw)
     def _resolve_model_path(self, path: str) -> str:
         """Resolve a user-provided model path into a confined, normalized path.
 

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1164,26 +1164,31 @@ class ModelCommands:
         This prevents saving models outside the intended directory via absolute
         paths or '..' segments.
         """
+        raw = (path or "").strip()
+        if not raw:
+            raise ValueError("Model save path must not be empty")
+        if os.path.isabs(raw):
+            # Do not allow absolute paths; callers must use relative paths under the models directory.
+            raise ValueError("Absolute model save paths are not allowed")
+
         # Base directory for saved models – use a directory under the current
         # working directory to avoid writing to arbitrary locations.
-        base_dir = os.path.abspath(os.path.join(os.getcwd(), "models"))
+        base_dir = os.path.join(os.getcwd(), "models")
         os.makedirs(base_dir, exist_ok=True)
 
-        # If the user gave an absolute path, interpret it relative to base_dir by
-        # stripping any leading path separator.
-        # This keeps behaviour similar (subdirectories still work) but confines
-        # writes to base_dir.
-        rel_path = str(path)
-        if os.path.isabs(rel_path):
-            rel_path = rel_path.lstrip(os.sep)
-
         # Join and normalize, then ensure the result stays within base_dir.
-        joined = os.path.join(base_dir, rel_path)
-        safe_path = os.path.abspath(os.path.normpath(joined))
-        if not safe_path.startswith(base_dir + os.sep) and safe_path != base_dir:
-            raise ValueError("Invalid model save path")
+        candidate = os.path.abspath(os.path.normpath(os.path.join(base_dir, raw)))
+        base_dir_abs = os.path.abspath(base_dir)
 
-        return safe_path
+        try:
+            common = os.path.commonpath([base_dir_abs, candidate])
+        except ValueError:
+            # Different drives on Windows, invalid paths, etc.
+            raise ValueError("Invalid model save path")
+        if common != base_dir_abs:
+            raise ValueError("Model save path escapes allowed directory")
+
+        return candidate
 
     def _resolve_model_path(self, path: str) -> str:
         """Resolve a user-provided model path into a confined, normalized path.

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1087,7 +1087,14 @@ class ModelCommands:
             return {"error": f"Model {model_id} not found"}
         try:
             # Resolve and validate the target path to avoid writing outside the models directory.
-            safe_path = self._resolve_model_save_path(path)
+            safe_path = os.path.realpath(self._resolve_model_save_path(path))
+            temp_real = os.path.realpath(tempfile.gettempdir())
+            try:
+                common = os.path.commonpath([temp_real, safe_path])
+            except ValueError:
+                raise ValueError("Resolved model save path is on a different drive or filesystem")
+            if common != temp_real:
+                raise ValueError("Resolved model save path must stay within the system temporary directory")
 
             model_data = self.models[model_id]
             model = self._ensure_model(model_id)

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1149,7 +1149,8 @@ class ModelCommands:
             return {
                 "status": "success",
                 "model_id": model_id,
-                "path": safe_path,
+                "path": path,
+                "resolved_path": safe_path,
                 "format": fmt,
                 "message": f"Model saved successfully",
             }

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1086,6 +1086,9 @@ class ModelCommands:
         if model_id not in self.models:
             return {"error": f"Model {model_id} not found"}
         try:
+            # Resolve and validate the target path to avoid writing outside the models directory.
+            safe_path = self._resolve_model_save_path(path)
+
             model_data = self.models[model_id]
             model = self._ensure_model(model_id)
             if model is None:
@@ -1133,25 +1136,54 @@ class ModelCommands:
                 "state_dict": state_dict,
             }
 
-            ext = os.path.splitext(str(path))[1].lower()
+            ext = os.path.splitext(str(safe_path))[1].lower()
             if ext in {".pth", ".pt"}:
-                save_checkpoint(path, save_data)
+                save_checkpoint(safe_path, save_data)
                 fmt = "rasptorch-npz"
             else:
                 import pickle
-                with open(path, "wb") as f:
+                with open(safe_path, "wb") as f:
                     pickle.dump(save_data, f)
                 fmt = "pickle"
             
             return {
                 "status": "success",
                 "model_id": model_id,
-                "path": path,
+                "path": safe_path,
                 "format": fmt,
                 "message": f"Model saved successfully",
             }
         except Exception as e:
             return {"error": str(e)}
+
+    def _resolve_model_save_path(self, path: str) -> str:
+        """
+        Resolve a user-supplied model save path to a safe absolute path within a
+        dedicated models directory.
+
+        This prevents saving models outside the intended directory via absolute
+        paths or '..' segments.
+        """
+        # Base directory for saved models – use a directory under the current
+        # working directory to avoid writing to arbitrary locations.
+        base_dir = os.path.abspath(os.path.join(os.getcwd(), "models"))
+        os.makedirs(base_dir, exist_ok=True)
+
+        # If the user gave an absolute path, interpret it relative to base_dir by
+        # stripping any leading path separator.
+        # This keeps behaviour similar (subdirectories still work) but confines
+        # writes to base_dir.
+        rel_path = str(path)
+        if os.path.isabs(rel_path):
+            rel_path = rel_path.lstrip(os.sep)
+
+        # Join and normalize, then ensure the result stays within base_dir.
+        joined = os.path.join(base_dir, rel_path)
+        safe_path = os.path.abspath(os.path.normpath(joined))
+        if not safe_path.startswith(base_dir + os.sep) and safe_path != base_dir:
+            raise ValueError("Invalid model save path")
+
+        return safe_path
 
     def _resolve_model_path(self, path: str) -> str:
         """Resolve a user-provided model path into a confined, normalized path.

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1183,9 +1183,9 @@ class ModelCommands:
             try:
                 common = os.path.commonpath([temp_real, candidate_real])
             except ValueError:
-                raise ValueError("Model save path must be within the system temporary directory")
+                raise ValueError("Model save path is on a different drive or filesystem")
             if common != temp_real:
-                raise ValueError("Model save path must be within the system temporary directory")
+                raise ValueError("Model save path attempts to escape the system temporary directory")
             return candidate_real
 
         # For relative paths, delegate to the shared model path resolver.

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1158,19 +1158,37 @@ class ModelCommands:
             return {"error": str(e)}
 
     def _resolve_model_save_path(self, path: str) -> str:
-        """
-        Resolve a user-supplied model save path using the same confinement logic
-        as `_resolve_model_path`.
+        """Resolve a user-supplied model save path to a safe absolute path.
 
-        This ensures that both loading and saving models share a single, consistent
-        path-validation implementation.
+        Absolute paths that already reside within the system temporary directory
+        are permitted as-is (e.g. paths produced by ``tempfile.NamedTemporaryFile``
+        used by the Streamlit UI download flow).  All other absolute paths are
+        rejected.  Relative paths are confined to the shared ``rasptorch_models``
+        directory under the system temporary directory.
+
+        ``os.path.realpath`` is used throughout so that symlink escapes are caught
+        by the ``os.path.commonpath`` confinement checks.
         """
         raw = (path or "").strip()
         if not raw:
             raise ValueError("Model save path must not be empty")
 
-        # Delegate to the shared model path resolver to avoid duplicated and
-        # potentially divergent validation logic.
+        # Resolve the system temp directory (handles any symlinks in /tmp etc.).
+        temp_real = os.path.realpath(tempfile.gettempdir())
+
+        if os.path.isabs(raw):
+            # Allow absolute paths that are already within the system temp dir
+            # (e.g. NamedTemporaryFile paths used by internal/UI callers).
+            candidate_real = os.path.realpath(raw)
+            try:
+                common = os.path.commonpath([temp_real, candidate_real])
+            except ValueError:
+                raise ValueError("Model save path must be within the system temporary directory")
+            if common != temp_real:
+                raise ValueError("Model save path must be within the system temporary directory")
+            return candidate_real
+
+        # For relative paths, delegate to the shared model path resolver.
         return self._resolve_model_path(raw)
     def _resolve_model_path(self, path: str) -> str:
         """Resolve a user-provided model path into a confined, normalized path.

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1188,17 +1188,19 @@ class ModelCommands:
         # Base directory where models are stored.
         base_dir = os.path.join(tempfile.gettempdir(), "rasptorch_models")
         os.makedirs(base_dir, exist_ok=True)
+        # Use realpath to resolve any symlinks in the base directory itself.
+        base_dir_real = os.path.realpath(base_dir)
 
-        candidate = os.path.abspath(os.path.normpath(os.path.join(base_dir, raw)))
-        base_dir_abs = os.path.abspath(base_dir)
+        # Resolve symlinks in the candidate path to guard against symlink escapes.
+        candidate = os.path.realpath(os.path.join(base_dir_real, raw))
 
         # Ensure the candidate path is within base_dir.
         try:
-            common = os.path.commonpath([base_dir_abs, candidate])
+            common = os.path.commonpath([base_dir_real, candidate])
         except ValueError:
             # Different drives on Windows, etc.
             raise ValueError("Invalid model path")
-        if common != base_dir_abs:
+        if common != base_dir_real:
             raise ValueError("Model path escapes allowed directory")
 
         return candidate

--- a/rasptorch/checkpoint.py
+++ b/rasptorch/checkpoint.py
@@ -100,7 +100,14 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     back by `load_checkpoint` with `allow_pickle=False`.
     """
 
-    safe_path = _resolve_checkpoint_path(path)
+    safe_path = os.path.realpath(_resolve_checkpoint_path(path))
+    temp_real = os.path.realpath(tempfile.gettempdir())
+    try:
+        common = os.path.commonpath([temp_real, safe_path])
+    except ValueError:
+        raise ValueError("Resolved checkpoint path is on a different drive or filesystem")
+    if common != temp_real:
+        raise ValueError("Resolved checkpoint path must stay within the system temporary directory")
 
     state_dict = _state_dict_to_numpy(payload.get("state_dict", {}))
     payload_meta = {k: _json_safe(v) for k, v in dict(payload).items() if k != "state_dict"}

--- a/rasptorch/checkpoint.py
+++ b/rasptorch/checkpoint.py
@@ -45,46 +45,49 @@ def _state_dict_to_numpy(state_dict: Any) -> dict[str, np.ndarray]:
 def _resolve_checkpoint_path(path: str) -> str:
     """Resolve a user-supplied checkpoint path to a safe absolute path.
 
-    Checkpoints are stored under a dedicated directory inside the system
-    temporary directory. Absolute paths that do not already reside under this
-    directory are interpreted relative to it, and any attempt to escape the
-    directory via '..' segments is rejected.
+    For relative paths, the result is confined to a dedicated subdirectory
+    inside the system temporary directory.  Absolute paths that already reside
+    within the system temporary directory are permitted as-is (callers such as
+    ``convert_legacy_torch_checkpoint`` need to write to caller-supplied
+    locations in the temp tree).  All other absolute paths are rejected.
+
+    ``os.path.realpath`` is used throughout so that symlink escapes are caught
+    by the ``os.path.commonpath`` confinement checks.
     """
     raw = str(path or "").strip()
     if not raw:
         raise ValueError("Checkpoint path must not be empty")
 
-    # Base directory for checkpoint files.
-    base_dir = os.path.join(tempfile.gettempdir(), "rasptorch_checkpoints")
-    os.makedirs(base_dir, exist_ok=True)
-    base_abs = os.path.abspath(base_dir)
+    # Resolve the system temp directory (handles any symlinks in /tmp etc.).
+    temp_real = os.path.realpath(tempfile.gettempdir())
 
-    candidate = raw
-    if os.path.isabs(candidate):
-        # If the absolute path is already under base_abs, keep it as-is.
-        abs_candidate = os.path.abspath(os.path.normpath(candidate))
+    if os.path.isabs(raw):
+        # For absolute paths, accept only those that resolve to somewhere inside
+        # the system temporary directory (e.g. pytest tmp_path, NamedTemporaryFile).
+        candidate_real = os.path.realpath(raw)
         try:
-            common = os.path.commonpath([base_abs, abs_candidate])
+            common = os.path.commonpath([temp_real, candidate_real])
         except ValueError:
             # Different drives on Windows, etc.
-            common = ""
-        if common == base_abs:
-            final_path = abs_candidate
-        else:
-            # Treat an external absolute path as relative to base_dir.
-            candidate = candidate.lstrip(os.sep)
-            joined = os.path.join(base_abs, candidate)
-            final_path = os.path.abspath(os.path.normpath(joined))
-    else:
-        joined = os.path.join(base_abs, candidate)
-        final_path = os.path.abspath(os.path.normpath(joined))
+            raise ValueError("Checkpoint path must be within the system temporary directory")
+        if common != temp_real:
+            raise ValueError("Checkpoint path must be within the system temporary directory")
+        return candidate_real
 
-    # Ensure the final path stays within base_abs.
+    # For relative paths, confine the result to the rasptorch_checkpoints directory.
+    base_dir = os.path.join(temp_real, "rasptorch_checkpoints")
+    os.makedirs(base_dir, exist_ok=True)
+    base_real = os.path.realpath(base_dir)
+
+    joined = os.path.join(base_real, raw)
+    final_path = os.path.realpath(joined)
+
+    # Ensure the resolved path stays within base_real (guards against '..' and symlinks).
     try:
-        common = os.path.commonpath([base_abs, final_path])
+        common = os.path.commonpath([base_real, final_path])
     except ValueError:
         raise ValueError("Invalid checkpoint path")
-    if common != base_abs:
+    if common != base_real:
         raise ValueError("Checkpoint path escapes allowed directory")
 
     return final_path

--- a/rasptorch/checkpoint.py
+++ b/rasptorch/checkpoint.py
@@ -48,6 +48,10 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     back by `load_checkpoint` with `allow_pickle=False`.
     """
 
+    # Normalize the path to an absolute path. Callers are responsible for any
+    # additional validation or confinement to a safe directory.
+    safe_path = os.path.abspath(os.path.normpath(str(path)))
+
     state_dict = _state_dict_to_numpy(payload.get("state_dict", {}))
     payload_meta = {k: _json_safe(v) for k, v in dict(payload).items() if k != "state_dict"}
     state_keys = sorted(state_dict.keys())
@@ -62,7 +66,7 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     for i, key in enumerate(state_keys):
         archive_items[f"arr_{i}"] = state_dict[key]
 
-    with open(path, "wb") as f:
+    with open(safe_path, "wb") as f:
         np.savez_compressed(f, **archive_items)
     return "rasptorch-npz"
 

--- a/rasptorch/checkpoint.py
+++ b/rasptorch/checkpoint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Any, Mapping
+import tempfile
 
 import numpy as np
 
@@ -41,6 +42,54 @@ def _state_dict_to_numpy(state_dict: Any) -> dict[str, np.ndarray]:
     return out
 
 
+def _resolve_checkpoint_path(path: str) -> str:
+    """Resolve a user-supplied checkpoint path to a safe absolute path.
+
+    Checkpoints are stored under a dedicated directory inside the system
+    temporary directory. Absolute paths that do not already reside under this
+    directory are interpreted relative to it, and any attempt to escape the
+    directory via '..' segments is rejected.
+    """
+    raw = str(path or "").strip()
+    if not raw:
+        raise ValueError("Checkpoint path must not be empty")
+
+    # Base directory for checkpoint files.
+    base_dir = os.path.join(tempfile.gettempdir(), "rasptorch_checkpoints")
+    os.makedirs(base_dir, exist_ok=True)
+    base_abs = os.path.abspath(base_dir)
+
+    candidate = raw
+    if os.path.isabs(candidate):
+        # If the absolute path is already under base_abs, keep it as-is.
+        abs_candidate = os.path.abspath(os.path.normpath(candidate))
+        try:
+            common = os.path.commonpath([base_abs, abs_candidate])
+        except ValueError:
+            # Different drives on Windows, etc.
+            common = ""
+        if common == base_abs:
+            final_path = abs_candidate
+        else:
+            # Treat an external absolute path as relative to base_dir.
+            candidate = candidate.lstrip(os.sep)
+            joined = os.path.join(base_abs, candidate)
+            final_path = os.path.abspath(os.path.normpath(joined))
+    else:
+        joined = os.path.join(base_abs, candidate)
+        final_path = os.path.abspath(os.path.normpath(joined))
+
+    # Ensure the final path stays within base_abs.
+    try:
+        common = os.path.commonpath([base_abs, final_path])
+    except ValueError:
+        raise ValueError("Invalid checkpoint path")
+    if common != base_abs:
+        raise ValueError("Checkpoint path escapes allowed directory")
+
+    return final_path
+
+
 def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     """Save a checkpoint without requiring torch.
 
@@ -48,9 +97,7 @@ def save_checkpoint(path: str, payload: Mapping[str, Any]) -> str:
     back by `load_checkpoint` with `allow_pickle=False`.
     """
 
-    # Normalize the path to an absolute path. Callers are responsible for any
-    # additional validation or confinement to a safe directory.
-    safe_path = os.path.abspath(os.path.normpath(str(path)))
+    safe_path = _resolve_checkpoint_path(path)
 
     state_dict = _state_dict_to_numpy(payload.get("state_dict", {}))
     payload_meta = {k: _json_safe(v) for k, v in dict(payload).items() if k != "state_dict"}
@@ -77,8 +124,10 @@ def load_checkpoint(path: str) -> dict[str, Any]:
     Raises ValueError if the file is not a rasptorch npz checkpoint.
     """
 
+    safe_path = _resolve_checkpoint_path(path)
+
     try:
-        archive = np.load(path, allow_pickle=False)
+        archive = np.load(safe_path, allow_pickle=False)
     except Exception as e:
         raise ValueError(f"Not a rasptorch checkpoint archive: {e}") from e
 
@@ -106,7 +155,7 @@ def load_checkpoint(path: str) -> dict[str, Any]:
             state_dict[str(key)] = np.asarray(archive[arr_key], dtype=np.float32)
 
     payload["state_dict"] = state_dict
-    payload["_checkpoint_path"] = os.path.abspath(path)
+    payload["_checkpoint_path"] = safe_path
     return payload
 
 


### PR DESCRIPTION
Fixes uncontrolled path expression vulnerabilities in `rasptorch/checkpoint.py` and `rasptorch/CLI/_cli_commands.py` (code scanning alerts [#25](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/25), [#26](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/26), [#27](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/27)).

The fix constrains all user-provided paths using `os.path.realpath` + `os.path.commonpath` confinement checks before any file operation, preventing directory traversal and symlink escape attacks.

## Changes Made

### `rasptorch/checkpoint.py`
- Added `_resolve_checkpoint_path()` helper that sanitizes user-supplied paths before use in `save_checkpoint` and `load_checkpoint`.
- **Relative paths** are confined to a dedicated `rasptorch_checkpoints` subdirectory under `tempfile.gettempdir()`.
- **Absolute paths** are accepted only if they already resolve within `tempfile.gettempdir()` (supporting `convert_legacy_torch_checkpoint` and `NamedTemporaryFile` callers); all others are rejected.
- Uses `os.path.realpath` throughout so symlink escapes are caught by the `commonpath` confinement check.

### `rasptorch/CLI/_cli_commands.py`
- `_resolve_model_save_path()`: Updated to use `os.path.realpath` + `os.path.commonpath` for symlink-resistant confinement. Absolute paths within `tempfile.gettempdir()` are permitted (for Streamlit UI callers using `NamedTemporaryFile`); all other absolute paths are rejected. Relative paths delegate to `_resolve_model_path`.
- `_resolve_model_path()`: Updated to use `os.path.realpath` instead of `os.path.abspath(os.path.normpath(...))` for symlink-resistant confinement of relative model load paths.
- `save_model()`: Routes the user-supplied path through `_resolve_model_save_path` before any file write; returns both the original `path` and the `resolved_path` in the response.

## Security Properties
- **Directory traversal**: `realpath` resolves `..` segments even for non-existent paths, so `../../etc/passwd` is caught by `commonpath`.
- **Symlink escapes**: `realpath` resolves all symlink components, so a symlink inside the allowed directory pointing outside is detected.
- **No new dependencies**: Only standard library (`os`, `tempfile`) used.

CodeQL reports 0 alerts after these changes.