### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -3042,7 +3042,10 @@ def _render_save_page() -> None:
     if Path(save_name).suffix.lower() != str(save_type).lower():
         save_name = str(Path(save_name).with_suffix(str(save_type)))
 
-    dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
+    allowed_exts = {".pkl", ".pth", ".pt"}
+    dl_ext = str(save_type).lower()
+    if dl_ext not in allowed_exts:
+        dl_ext = ".pkl"
     with tempfile.NamedTemporaryFile(delete=False, suffix=dl_ext) as f:
         tmp_out = f.name
     res = cmds.save_model(selected, tmp_out)


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/33](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/33)

General fix: decouple filesystem path components from untrusted input by validating against a strict allowlist before using them in path APIs.

Best fix here: stop deriving `dl_ext` from `save_name` and derive it only from `save_type` (which is selected from a fixed set in the UI). Also add a defensive fallback to `.pkl` if `save_type` is ever outside the allowlist. This preserves current functionality (user still chooses among `.pkl/.pth/.pt`, and download filename still uses `save_name`) while removing tainted data from `NamedTemporaryFile(..., suffix=...)`.

Change needed in `rasptorch/CLI/ui/app.py` around lines 3045–3047:
- Replace `dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)` with allowlist-based derivation from `save_type`.
- Keep all other logic intact.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
