### PR TITLE
Potential fix for code scanning alert no. 32: Uncontrolled data used in path expression

### DIFF
--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 
 from typing import Any, Dict, Tuple, List, Optional, Callable
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 import re
 import hashlib
 import numpy as np
@@ -1313,6 +1313,38 @@ class ModelCommands:
         # so it is safe to use directly as a filename component.
         name_hash = hashlib.sha256(raw_posix.encode("utf-8", errors="replace")).hexdigest()
         return os.path.join(base_dir_real, name_hash)
+
+    def read_saved_model_bytes(self, resolved_path: str) -> Dict[str, Any]:
+        """Read bytes from a command-resolved model path after strict confinement validation."""
+        try:
+            raw = str(resolved_path or "").strip()
+            if not raw:
+                return {"error": "Missing resolved model path"}
+
+            safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
+            candidate = Path(raw).resolve()
+
+            try:
+                rel = candidate.relative_to(safe_root)
+            except ValueError:
+                return {"error": "Resolved save path is outside the allowed models directory"}
+
+            if len(rel.parts) != 1 or not re.fullmatch(r"[a-f0-9]{64}", rel.name):
+                return {"error": "Resolved save path does not match expected storage layout"}
+
+            safe_candidate = (safe_root / rel.name).resolve()
+            try:
+                safe_candidate.relative_to(safe_root)
+            except ValueError:
+                return {"error": "Resolved save path is outside the allowed models directory"}
+            if safe_candidate != candidate:
+                return {"error": "Resolved save path does not match expected storage layout"}
+            if not safe_candidate.exists():
+                return {"error": "Saved model file was not found in the expected models directory."}
+
+            return {"status": "success", "data": safe_candidate.read_bytes()}
+        except Exception as e:
+            return {"error": str(e)}
 
     def _safe_torch_load(self, path: str) -> Dict[str, Any]:
         """Safely load a torch checkpoint, using weights_only=True to avoid

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1314,33 +1314,32 @@ class ModelCommands:
         name_hash = hashlib.sha256(raw_posix.encode("utf-8", errors="replace")).hexdigest()
         return os.path.join(base_dir_real, name_hash)
 
-    def read_saved_model_bytes(self, resolved_path: str) -> Dict[str, Any]:
-        """Read bytes from a command-resolved model path after strict confinement validation."""
+    def read_saved_model_bytes(self, save_path: str, resolved_path: str) -> Dict[str, Any]:
+        """Read bytes from a saved model after validating resolved-path agreement and confinement."""
         try:
-            raw = str(resolved_path or "").strip()
-            if not raw:
+            resolved_raw = str(resolved_path or "").strip()
+            if not resolved_raw:
                 return {"error": "Missing resolved model path"}
 
+            expected = Path(self._resolve_model_save_path(save_path)).resolve()
             safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
-            safe_root_posix = safe_root.as_posix()
-            raw_posix = raw.replace("\\", "/")
-            prefix = safe_root_posix + "/"
-            if not raw_posix.startswith(prefix):
-                return {"error": "Resolved save path is outside the allowed models directory"}
-            rel_name = raw_posix[len(prefix):]
-
-            if "/" in rel_name or not re.fullmatch(r"[a-f0-9]{64}", rel_name):
-                return {"error": "Resolved save path does not match expected storage layout"}
-
-            safe_candidate = (safe_root / rel_name).resolve()
             try:
-                safe_candidate.relative_to(safe_root)
+                expected.relative_to(safe_root)
             except ValueError:
                 return {"error": "Resolved save path is outside the allowed models directory"}
-            if not safe_candidate.exists():
+
+            expected_name = expected.name
+            if not re.fullmatch(r"[a-f0-9]{64}", expected_name):
+                return {"error": "Resolved save path does not match expected storage layout"}
+
+            resolved_norm = resolved_raw.replace("\\", "/")
+            if resolved_norm != expected.as_posix():
+                return {"error": "Resolved save path does not match expected storage layout"}
+
+            if not expected.exists():
                 return {"error": "Saved model file was not found in the expected models directory."}
 
-            return {"status": "success", "data": safe_candidate.read_bytes()}
+            return {"status": "success", "data": expected.read_bytes()}
         except Exception as e:
             return {"error": str(e)}
 

--- a/rasptorch/CLI/_cli_commands.py
+++ b/rasptorch/CLI/_cli_commands.py
@@ -1322,23 +1322,21 @@ class ModelCommands:
                 return {"error": "Missing resolved model path"}
 
             safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
-            candidate = Path(raw).resolve()
-
-            try:
-                rel = candidate.relative_to(safe_root)
-            except ValueError:
+            safe_root_posix = safe_root.as_posix()
+            raw_posix = raw.replace("\\", "/")
+            prefix = safe_root_posix + "/"
+            if not raw_posix.startswith(prefix):
                 return {"error": "Resolved save path is outside the allowed models directory"}
+            rel_name = raw_posix[len(prefix):]
 
-            if len(rel.parts) != 1 or not re.fullmatch(r"[a-f0-9]{64}", rel.name):
+            if "/" in rel_name or not re.fullmatch(r"[a-f0-9]{64}", rel_name):
                 return {"error": "Resolved save path does not match expected storage layout"}
 
-            safe_candidate = (safe_root / rel.name).resolve()
+            safe_candidate = (safe_root / rel_name).resolve()
             try:
                 safe_candidate.relative_to(safe_root)
             except ValueError:
                 return {"error": "Resolved save path is outside the allowed models directory"}
-            if safe_candidate != candidate:
-                return {"error": "Resolved save path does not match expected storage layout"}
             if not safe_candidate.exists():
                 return {"error": "Saved model file was not found in the expected models directory."}
 

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2913,17 +2913,25 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
             if "error" in res:
                 st.error(res["error"])
             else:
-                # Read the saved file from the resolved path
+                # Read the saved file from the resolved path, but only if it is inside
+                # the expected Rasptorch models storage directory.
                 resolved_path = res.get("resolved_path")
-                if resolved_path and Path(resolved_path).exists():
-                    data = Path(resolved_path).read_bytes()
-                    dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
-                    st.download_button(
-                        "Download",
-                        data=data,
-                        file_name=save_name or f"model_{selected}{dl_ext}",
-                        mime="application/octet-stream",
-                    )
+                if resolved_path:
+                    try:
+                        rp = Path(resolved_path).resolve()
+                        safe_root = (Path(tempfile.gettempdir()) / "rasptorch" / "models").resolve()
+                        rp.relative_to(safe_root)
+                        if rp.exists():
+                            data = rp.read_bytes()
+                            dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
+                            st.download_button(
+                                "Download",
+                                data=data,
+                                file_name=save_name or f"model_{selected}{dl_ext}",
+                                mime="application/octet-stream",
+                            )
+                    except Exception:
+                        st.error("Resolved save path is invalid or outside the allowed models directory.")
 
     st.subheader("Load")
     up = st.file_uploader("Load a saved model (.pkl/.pth/.pt)", type=["pkl", "pth", "pt"], accept_multiple_files=False)

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2914,26 +2914,13 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
                 st.error(res["error"])
             else:
                 try:
-                    import re as re_module
-
                     resolved_raw = str(res.get("resolved_path") or "").strip()
-                    if not resolved_raw:
-                        raise ValueError("Missing resolved save path")
-
-                    resolved_path = Path(resolved_raw).resolve()
-                    safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
-                    try:
-                        rel_path = resolved_path.relative_to(safe_root)
-                    except ValueError:
-                        raise ValueError("Resolved save path is outside the allowed models directory")
-
-                    if len(rel_path.parts) != 1 or not re_module.fullmatch(r"[a-f0-9]{64}", rel_path.name):
-                        raise ValueError("Resolved save path does not match expected storage layout")
-                    if not resolved_path.exists():
-                        st.error("Saved model file was not found in the expected models directory.")
+                    bytes_result = cmds.read_saved_model_bytes(resolved_raw)
+                    if "error" in bytes_result:
+                        st.error(bytes_result["error"])
                         return
 
-                    data = resolved_path.read_bytes()
+                    data = bytes_result.get("data", b"")
                     st.download_button(
                         "Download",
                         data=data,

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2915,7 +2915,7 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
             else:
                 try:
                     resolved_raw = str(res.get("resolved_path") or "").strip()
-                    bytes_result = cmds.read_saved_model_bytes(resolved_raw)
+                    bytes_result = cmds.read_saved_model_bytes(save_name, resolved_raw)
                     if "error" in bytes_result:
                         st.error(bytes_result["error"])
                         return

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2917,15 +2917,16 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
                 # convention as the command layer, instead of trusting a returned path.
                 try:
                     safe_root = (Path(tempfile.gettempdir()) / "rasptorch" / "models").resolve()
-                    input_path = (save_name or "").strip()
-                    normalized_input = str(Path(input_path))
-                    ext = Path(normalized_input).suffix or ".pkl"
-                    key = hashlib.sha256(normalized_input.encode("utf-8")).hexdigest() + ext
+                    allowed_exts = {".pkl", ".pth", ".pt"}
+                    trusted_ext = str(save_type).lower() if str(save_type).lower() in allowed_exts else ".pkl"
+                    base_name = Path((save_name or f"model_{selected}")).stem
+                    key_source = f"{base_name}{trusted_ext}"
+                    key = hashlib.sha256(key_source.encode("utf-8")).hexdigest() + trusted_ext
                     rp = (safe_root / key).resolve()
                     rp.relative_to(safe_root)
                     if rp.exists():
                         data = rp.read_bytes()
-                        dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
+                        dl_ext = trusted_ext
                         st.download_button(
                             "Download",
                             data=data,

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2914,12 +2914,24 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
                 st.error(res["error"])
             else:
                 try:
-                    resolved_path = Path(res.get("resolved_path", "")).resolve()
+                    import re as re_module
+
+                    resolved_raw = str(res.get("resolved_path") or "").strip()
+                    if not resolved_raw:
+                        raise ValueError("Missing resolved save path")
+
+                    resolved_path = Path(resolved_raw).resolve()
                     safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
                     try:
-                        resolved_path.relative_to(safe_root)
+                        rel_path = resolved_path.relative_to(safe_root)
                     except ValueError:
                         raise ValueError("Resolved save path is outside the allowed models directory")
+
+                    if len(rel_path.parts) != 1 or not re_module.fullmatch(r"[a-f0-9]{64}", rel_path.name):
+                        raise ValueError("Resolved save path does not match expected storage layout")
+                    if not resolved_path.exists():
+                        st.error("Saved model file was not found in the expected models directory.")
+                        return
 
                     data = resolved_path.read_bytes()
                     st.download_button(

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2913,28 +2913,21 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
             if "error" in res:
                 st.error(res["error"])
             else:
-                # Derive the saved file path locally using the same safe storage
-                # convention as the command layer, instead of trusting a returned path.
                 try:
-                    safe_root = (Path(tempfile.gettempdir()) / "rasptorch" / "models").resolve()
-                    allowed_exts = {".pkl", ".pth", ".pt"}
-                    trusted_ext = str(save_type).lower() if str(save_type).lower() in allowed_exts else ".pkl"
-                    base_name = Path((save_name or f"model_{selected}")).stem
-                    key_source = f"{base_name}{trusted_ext}"
-                    key = hashlib.sha256(key_source.encode("utf-8")).hexdigest() + trusted_ext
-                    rp = (safe_root / key).resolve()
-                    rp.relative_to(safe_root)
-                    if rp.exists():
-                        data = rp.read_bytes()
-                        dl_ext = trusted_ext
-                        st.download_button(
-                            "Download",
-                            data=data,
-                            file_name=save_name or f"model_{selected}{dl_ext}",
-                            mime="application/octet-stream",
-                        )
-                    else:
-                        st.error("Saved model file was not found in the expected models directory.")
+                    resolved_path = Path(res.get("resolved_path", "")).resolve()
+                    safe_root = (Path(tempfile.gettempdir()) / "rasptorch_models").resolve()
+                    try:
+                        resolved_path.relative_to(safe_root)
+                    except ValueError:
+                        raise ValueError("Resolved save path is outside the allowed models directory")
+
+                    data = resolved_path.read_bytes()
+                    st.download_button(
+                        "Download",
+                        data=data,
+                        file_name=save_name or f"model_{selected}{save_type}",
+                        mime="application/octet-stream",
+                    )
                 except Exception:
                     st.error("Resolved save path is invalid or outside the allowed models directory.")
 

--- a/rasptorch/CLI/ui/app.py
+++ b/rasptorch/CLI/ui/app.py
@@ -2913,25 +2913,29 @@ Tip: set `RASPTORCH_UI_3D_RENDER=canvas3d` to use the WebGL-free renderer on any
             if "error" in res:
                 st.error(res["error"])
             else:
-                # Read the saved file from the resolved path, but only if it is inside
-                # the expected Rasptorch models storage directory.
-                resolved_path = res.get("resolved_path")
-                if resolved_path:
-                    try:
-                        rp = Path(resolved_path).resolve()
-                        safe_root = (Path(tempfile.gettempdir()) / "rasptorch" / "models").resolve()
-                        rp.relative_to(safe_root)
-                        if rp.exists():
-                            data = rp.read_bytes()
-                            dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
-                            st.download_button(
-                                "Download",
-                                data=data,
-                                file_name=save_name or f"model_{selected}{dl_ext}",
-                                mime="application/octet-stream",
-                            )
-                    except Exception:
-                        st.error("Resolved save path is invalid or outside the allowed models directory.")
+                # Derive the saved file path locally using the same safe storage
+                # convention as the command layer, instead of trusting a returned path.
+                try:
+                    safe_root = (Path(tempfile.gettempdir()) / "rasptorch" / "models").resolve()
+                    input_path = (save_name or "").strip()
+                    normalized_input = str(Path(input_path))
+                    ext = Path(normalized_input).suffix or ".pkl"
+                    key = hashlib.sha256(normalized_input.encode("utf-8")).hexdigest() + ext
+                    rp = (safe_root / key).resolve()
+                    rp.relative_to(safe_root)
+                    if rp.exists():
+                        data = rp.read_bytes()
+                        dl_ext = Path(save_name).suffix.lower() if save_name else str(save_type)
+                        st.download_button(
+                            "Download",
+                            data=data,
+                            file_name=save_name or f"model_{selected}{dl_ext}",
+                            mime="application/octet-stream",
+                        )
+                    else:
+                        st.error("Saved model file was not found in the expected models directory.")
+                except Exception:
+                    st.error("Resolved save path is invalid or outside the allowed models directory.")
 
     st.subheader("Load")
     up = st.file_uploader("Load a saved model (.pkl/.pth/.pt)", type=["pkl", "pth", "pt"], accept_multiple_files=False)


### PR DESCRIPTION
Potential fix for [https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/32](https://github.com/Joshua-Ludolf/rasptorch/security/code-scanning/32)

General fix: ensure any path used in file reads is validated against a known safe base directory after normalization/realpath resolution, and reject paths outside that base.

Best single fix here (without changing functionality): in `rasptorch/CLI/ui/app.py` at the save/download section (around lines 2916–2920), validate `resolved_path` before `read_bytes()` by:
1. Resolving `resolved_path` to a canonical absolute path.
2. Resolving the expected models storage directory (using temp dir + `rasptorch/models`, matching backend storage convention).
3. Ensuring `resolved_path` is within that base via `relative_to` check.
4. Only then read bytes; otherwise show an error.

No new dependency is needed; use existing `Path` and already-imported `tempfile`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
